### PR TITLE
Added sources.list to repair usage of buster (which is no longer stable).

### DIFF
--- a/kafka_sbuild/Dockerfile
+++ b/kafka_sbuild/Dockerfile
@@ -23,7 +23,9 @@
 #
 FROM schaliasos/sbuild:latest
 
-RUN sudo apt -yqq update && sudo apt -yqq install libcurl4-openssl-dev libssl-dev
+COPY sources.list /etc/apt/sources.list
+RUN sudo apt-get -yqq update \
+ && sudo apt-get -yqq install libcurl4-openssl-dev libssl-dev
 RUN pip3 install requests BeautifulSoup4 kafka-python fasten pycurl
 RUN sudo pip3 install requests BeautifulSoup4 kafka-python fasten pycurl
 

--- a/kafka_sbuild/cscout.Dockerfile
+++ b/kafka_sbuild/cscout.Dockerfile
@@ -23,7 +23,9 @@
 #
 FROM schaliasos/sbuild-cscout:latest
 
-RUN sudo apt -yqq update && sudo apt -yqq install libcurl4-openssl-dev libssl-dev
+COPY sources.list /etc/apt/sources.list
+RUN sudo apt-get -yqq update \
+ && sudo apt-get -yqq install libcurl4-openssl-dev libssl-dev
 RUN pip3 install requests BeautifulSoup4 kafka-python fasten pycurl
 RUN sudo pip3 install requests BeautifulSoup4 kafka-python fasten pycurl
 

--- a/kafka_sbuild/entrypoint.py
+++ b/kafka_sbuild/entrypoint.py
@@ -71,8 +71,7 @@ class IntermediatePluginError(Exception):
 def create_dir(dir_name):
     """Safely create directory package-version.
     """
-    if not os.path.exists(dir_name):
-        os.makedirs(dir_name)
+    os.makedirs(dir_name, exist_ok = True)
     return dir_name
 
 
@@ -695,6 +694,7 @@ class CScoutKafkaPlugin(KafkaPlugin):
             message = self.create_message(self.state.record, {"status": "failed"})
             self.emit_message(self.log_topic, message, "failed", "")
         os.chdir(self.state.old_cwd)
+        self.flush_logs()
         self._cleanup()
         # End
         self.state = None

--- a/kafka_sbuild/sources.list
+++ b/kafka_sbuild/sources.list
@@ -1,0 +1,11 @@
+deb http://deb.debian.org/debian buster main contrib non-free
+deb-src http://deb.debian.org/debian buster main contrib non-free
+
+deb http://deb.debian.org/debian buster-updates main contrib non-free
+deb-src http://deb.debian.org/debian buster-updates main contrib non-free
+
+deb http://deb.debian.org/debian buster-backports main contrib non-free
+deb-src http://deb.debian.org/debian buster-backports main contrib non-free
+
+deb http://security.debian.org/debian-security/ buster/updates main contrib non-free
+deb-src http://security.debian.org/debian-security/ buster/updates main contrib non-free

--- a/kafka_sbuild/svf.Dockerfile
+++ b/kafka_sbuild/svf.Dockerfile
@@ -23,6 +23,7 @@
 #
 FROM schaliasos/sbuild-svf:latest
 
+COPY sources.list /etc/apt/sources.list
 RUN sudo apt -yqq update && sudo apt -yqq install libcurl4-openssl-dev libssl-dev
 RUN pip3 install requests BeautifulSoup4 kafka-python fasten pycurl
 RUN sudo pip3 install requests BeautifulSoup4 kafka-python fasten pycurl


### PR DESCRIPTION
Dockerfiles cannot be built successfully without setting sources.list to point to the new locations of buster (which stopped being stable a while a go). Or we should upgrade to Debian 11 bullseye.